### PR TITLE
Client message timestamp

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,7 +1,11 @@
 import { PrismaClient } from "@prisma/client"
 import { gracefulExit } from "./utils/process";
 
-export type Unsaved<T> = Omit<T, "id" | "createdAt" | "updatedAt">
+export type Unsaved<T> = Omit<T, "id" | "createdAt" | "updatedAt"> & {
+  // make timestamps optional
+  createdAt?: Date
+  updatedAt?: Date
+}
 
 export type CollectionName = Exclude<keyof PrismaClient,`$${string}`>
 

--- a/lib/routes/graphql/resolvers.ts
+++ b/lib/routes/graphql/resolvers.ts
@@ -5,6 +5,7 @@ import { GraphQLContext, RootParent }                                           
 import { IResolvers, withFilter }                                                 from "apollo-server-koa"
 import db                                                                         from "../../db"
 import _                                                                          from 'lodash'
+import { Json }                                                                   from "../../typings/lang"
 
 // ---------------------------
 // Types
@@ -26,6 +27,8 @@ export interface MessageSubscriptionArgs extends Partial<ConversationSelectArgs>
 export interface SendMessageArgs {
   conversationId: number
   text: string
+  metadata?: Json
+  timestamp?: Date
 }
 
 // ---------------------------
@@ -61,7 +64,10 @@ const resolvers : IResolvers = {
 
   Mutation: {
     sendMessage: async (parent: RootParent, args: SendMessageArgs, ctx : GraphQLContext) => {
-      return ctx.abilities.sendTextMessage(args.conversationId, args.text);
+      return ctx.abilities.sendTextMessage(args.conversationId, args.text, {
+        metadata: args.metadata,
+        timestamp: args.timestamp
+      });
     },
 
     startTyping: async (parent: RootParent, args: { conversationId: number }, ctx : GraphQLContext) => {

--- a/lib/routes/graphql/schema.gql
+++ b/lib/routes/graphql/schema.gql
@@ -26,7 +26,12 @@ type Mutation {
   #   - sendLink
   #   - sendXXX
 
-  sendMessage(conversationId: Int!, text: String!) : Message!
+  sendMessage(
+    conversationId: Int!,
+    text: String!,
+    timestamp: DateTime,
+    metadata: JSON
+  ) : Message!
   startTyping(conversationId: Int!) : Conversation!
   stopTyping(conversationId: Int!) : Conversation!
   markAsRead(conversationId: Int!) : ReadReceipt!

--- a/lib/services/abilities/message_abilities.ts
+++ b/lib/services/abilities/message_abilities.ts
@@ -4,7 +4,7 @@ import { MessagesApi }                                              from "sunshi
 import config                                                       from "../../config"
 import db, { Unsaved }                                              from "../../db"
 import { MessageContent }                                           from "../../typings/goodchat"
-import { Json } from "../../typings/lang"
+import { Json }                                                     from "../../typings/lang"
 import { throwForbidden }                                           from "../../utils/errors"
 import { conversationAbilities }                                    from "./conversation_abilities"
 import { CollectionArgs, cursorFilter, normalizePages }             from "./helpers"

--- a/lib/services/abilities/message_abilities.ts
+++ b/lib/services/abilities/message_abilities.ts
@@ -4,6 +4,7 @@ import { MessagesApi }                                              from "sunshi
 import config                                                       from "../../config"
 import db, { Unsaved }                                              from "../../db"
 import { MessageContent }                                           from "../../typings/goodchat"
+import { Json } from "../../typings/lang"
 import { throwForbidden }                                           from "../../utils/errors"
 import { conversationAbilities }                                    from "./conversation_abilities"
 import { CollectionArgs, cursorFilter, normalizePages }             from "./helpers"
@@ -13,6 +14,11 @@ export type MessagesArgs = CollectionArgs & {
   conversationId?: number
   id?: number
   order?: 'asc' | 'desc'
+}
+
+export type SendMessageOptions = {
+  metadata?: Json,
+  timestamp?: Date | number
 }
 
 /**
@@ -26,6 +32,17 @@ export function messageAbilities(staff: Staff) {
 
   const sunshineMessages = new MessagesApi();
   const conversations = conversationAbilities(staff);
+
+  const assertTimestamp = (timestamp: number | Date) => {
+    const now = Date.now();
+    const time = new Date(timestamp).getTime();
+    const oneHourAgo = now - 60 * 60 * 1000;
+    const inTenMinutes = now + 10 * 60 * 1000;
+
+    if (time < oneHourAgo || time > inTenMinutes) {
+      throwForbidden("errors.invalid_timestamp");
+    }
+  }
 
   /* Listing messages that I have access to */
 
@@ -64,7 +81,7 @@ export function messageAbilities(staff: Staff) {
 
   /* Sending message to a conversation (if entitled to) */
 
-  const sendMessage = async (conversationId: number, content: MessageContent) => {
+  const sendMessage = async (conversationId: number, content: MessageContent, opts? : SendMessageOptions) => {
     const conversation = await conversations.getConversationById(conversationId);
 
     if (conversation === null) throwForbidden();
@@ -75,8 +92,15 @@ export function messageAbilities(staff: Staff) {
       sunshineMessageId: null,
       authorType: AuthorType.STAFF,
       authorId: staff.id,
-      metadata: {}
+      metadata: opts?.metadata || {}
     };
+
+    if (opts?.timestamp) {
+      const date = new Date(opts.timestamp);
+      assertTimestamp(date);
+      unsaveMessage.createdAt = date;
+      unsaveMessage.updatedAt = date;
+    }
 
     await conversations.joinConversation(conversationId)
 
@@ -117,11 +141,11 @@ export function messageAbilities(staff: Staff) {
     });
   }
 
-  const sendTextMessage = (conversationId: number, text: string) => {
+  const sendTextMessage = (conversationId: number, text: string, opts?: SendMessageOptions) => {
     return sendMessage(conversationId, {
       type: 'text',
       text: text
-    })
+    }, opts)
   }
 
   return {

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,6 +8,7 @@
     "not_found": "Resource not found",
     "disabled": "Disabled feature",
     "unprocessable": "Unprocessable Entity",
+    "invalid_timestamp": "Invalid timestamp",
     "pagination": {
       "invalid_cursor": "Invalid cursor"
     },

--- a/locales/zh_tw.json
+++ b/locales/zh_tw.json
@@ -8,6 +8,7 @@
     "not_found": "Resource not found",
     "disabled": "Disabled feature",
     "unprocessable": "Unprocessable Entity",
+    "invalid_timestamp": "Invalid timestamp",
     "pagination": {
       "invalid_cursor": "Invalid cursor"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api.goodchat",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "omnichannel chat solution built for structured integrations with transactional systems",
   "main": "dist/bin/serve.js",
   "scripts": {

--- a/specs/integration/api/graphql/send_message.mutation.spec.ts
+++ b/specs/integration/api/graphql/send_message.mutation.spec.ts
@@ -329,4 +329,74 @@ describe('GraphQL SendMessage mutations', () => {
       });
     })
   });
+
+  describe('Options', () => {
+    beforeEach(async () => {
+      setCurrentUser(admin)
+    })
+
+    it('can set the timestamp of the message as DateTime', async () => {
+      const timestamp = new Date(Date.now() - 60000);
+
+      const { errors, data } : any = await gqlAgent.mutate({
+        variables: { timestamp },
+        mutation: gql`
+          mutation SendMessage($timestamp: DateTime) {
+            sendMessage(
+              conversationId: ${publicConversation.id},
+              text: "Hi Steve",
+              timestamp: $timestamp
+            ) {
+              createdAt
+              updatedAt
+              content
+              conversationId
+            }
+          }
+        `
+      })
+
+      expect(errors).to.be.undefined
+      expect(await db.message.count()).to.equal(1)
+      expect(data).to.deep.equal({
+        sendMessage: {
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          conversationId: publicConversation.id,
+          content: { text: 'Hi Steve', type: 'text' }
+        }
+      })
+    })
+
+    it('can set the metadata of the message', async () => {
+      const metadata = { some: { meta: 'data '} };
+
+      const { errors, data } : any = await gqlAgent.mutate({
+        variables: { metadata },
+        mutation: gql`
+          mutation SendMessage($metadata: JSON) {
+            sendMessage(
+              conversationId: ${publicConversation.id},
+              text: "Hi Steve",
+              metadata: $metadata
+            ) {
+              metadata
+              content
+              conversationId
+            }
+          }
+        `
+      })
+
+      expect(errors).to.be.undefined
+      expect(await db.message.count()).to.equal(1)
+      expect(data).to.deep.equal({
+        sendMessage: {
+          metadata: metadata,
+          conversationId: publicConversation.id,
+          content: { text: 'Hi Steve', type: 'text' }
+        }
+      })
+    })
+  });
 });


### PR DESCRIPTION
Clients can now set a timestamp when posting a message to the server

Basic security rules:

- timestamp cannot be older than one hour ago
- timestamp cannot be over 10 minutes in the future