### PR TITLE
ADD: Computed counters for conversations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "frigus02.vscode-sql-tagged-template-literals"
+  ]
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -21,6 +21,11 @@ const prisma = new PrismaClient({
   )
 });
 
+//
+// We export $queryRaw as a sql method to allow syntax coloring on template strings
+//
+export const sql = prisma.$queryRaw.bind(prisma)
+
 gracefulExit(() => prisma.$disconnect());
 
 export default prisma

--- a/lib/routes/graphql/resolvers.ts
+++ b/lib/routes/graphql/resolvers.ts
@@ -2,6 +2,7 @@ import { MessageEvent, pubsub, PubSubAction, PubSubEvent, ReadReceiptEvent }    
 import { Conversation, ConversationType, Customer, Message, Staff }               from "@prisma/client"
 import { GraphQLContext, RootParent }                                             from "."
 import { IResolvers, withFilter }                                                 from "apollo-server-koa"
+import * as computer                                                              from "../../services/computer"
 import db                                                                         from "../../db"
 import _                                                                          from 'lodash'
 import { Json }                                                                   from "../../typings/lang"
@@ -205,6 +206,26 @@ const resolvers : IResolvers = {
           conversationId: parent.id
         }
       });
+    },
+
+    _computed(parent: Conversation) {
+      //
+      // We let the nested resolvers compute the properties to avoid
+      // computation of fields we do not need
+      //
+      return {
+        conversationId: parent.id
+      };
+    }
+  },
+
+  ConversationAggregates: {
+    unreadMessageCount({ conversationId }, args: BaseArgs, ctx: GraphQLContext) {
+      return computer.computeUnreadMessageCount(ctx.staff.id, conversationId);
+    },
+
+    totalMessageCount({ conversationId }) {
+      return computer.computeMessageCount(conversationId);
     }
   },
 

--- a/lib/routes/graphql/schema.gql
+++ b/lib/routes/graphql/schema.gql
@@ -85,6 +85,13 @@ type Conversation {
   messages(limit: Int, after: Int): [Message!]!
   readReceipts: [ReadReceipt!]!
   staffs: [Staff!]!
+  _computed: ConversationAggregates!
+}
+
+type ConversationAggregates {
+  conversationId: Int!
+  unreadMessageCount: Int!
+  totalMessageCount: Int!
 }
 
 type Message {

--- a/lib/services/computer.ts
+++ b/lib/services/computer.ts
@@ -1,0 +1,52 @@
+import db, { sql }  from "../db"
+import _            from "lodash"
+
+/**
+ * Returns the number of unread messages of a user for a given conversation
+ *
+ * @export
+ * @param {number} staffId
+ * @param {number} conversationId
+ * @returns {Promise<number>}
+ */
+export async function computeUnreadMessageCount(staffId: number, conversationId: number) : Promise<number> {
+  const [{ count }] = await sql`
+    WITH last_read_timestamps AS (
+      SELECT rr."conversationId", m."createdAt" AS timestamp
+        FROM "ReadReceipt" rr
+        JOIN "Message" m ON m.id = rr."lastReadMessageId"
+        WHERE rr."userType" = 'STAFF' AND rr."userId" = ${staffId}
+    )
+    SELECT count(m.id) FROM "Message" m
+      LEFT JOIN "ReadReceipt" rr ON (
+        rr."conversationId" = ${conversationId} AND
+        rr."userType" = 'STAFF' AND
+        rr."userId" = ${staffId}
+      )
+      LEFT JOIN last_read_timestamps AS lrt ON lrt."conversationId" = rr."conversationId"
+    WHERE m."conversationId" = ${conversationId}
+      AND (m."createdAt" > lrt.timestamp OR lrt.timestamp IS NULL)
+  `
+
+  return count;
+}
+
+/**
+ * Returns the total number of messages in a conversation
+ *
+ * @export
+ * @param {number} conversationId
+ * @returns {Promise<number>}
+ */
+export async function computeMessageCount(conversationId: number) : Promise<number> {
+  const { _count } = await db.message.aggregate({
+    where: {
+      conversationId
+    },
+    _count: {
+      id: true
+    }
+  })
+
+  return _count.id
+}

--- a/specs/unit/services/computer.spec.ts
+++ b/specs/unit/services/computer.spec.ts
@@ -1,0 +1,78 @@
+import { GoodChatPermissions }   from '../../../lib/typings/goodchat'
+import * as factories            from '../../factories'
+import * as computer             from '../../../lib/services/computer'
+import { expect }                from 'chai'
+import _                         from 'lodash'
+import {
+  AuthorType,
+  Conversation,
+  ConversationType,
+  Message,
+  Staff
+} from '@prisma/client'
+
+
+describe('Services/computer', () => {
+  let user : Staff
+  let conversation : Conversation
+  let messages : Message[]
+
+  beforeEach(async () => {
+    const now = Date.now();
+
+    user = await factories.staffFactory.create({ permissions: [GoodChatPermissions.ADMIN] });
+    conversation = await factories.conversationFactory.create({ type: ConversationType.CUSTOMER });
+    messages = [
+      await factories.messageFactory.create({ conversationId: conversation.id, createdAt: new Date(now + 1000) }),
+      await factories.messageFactory.create({ conversationId: conversation.id, createdAt: new Date(now + 2000) }),
+      await factories.messageFactory.create({ conversationId: conversation.id, createdAt: new Date(now + 3000) }),
+      await factories.messageFactory.create({ conversationId: conversation.id, createdAt: new Date(now + 4000) }),
+      await factories.messageFactory.create({ conversationId: conversation.id, createdAt: new Date(now + 5000) })
+    ]
+  });
+
+  describe('Computing the total message count', () => {
+
+    it('returns the count of all messages', async () => {
+      expect(messages.length).to.eq(5)
+      expect(
+        await computer.computeMessageCount(conversation.id)
+      ).to.eq(5)
+    })
+  })
+
+  describe('Computing the unread message count', () => {
+
+    context('of as single conversation', () => {
+
+      context('when no read receipt exists', () => {
+
+        it('returns the count of all messages', async () => {
+          expect(messages.length).to.eq(5)
+          expect(
+            await computer.computeUnreadMessageCount(user.id, conversation.id)
+          ).to.eq(5)
+        })
+      })
+
+      context('when a read receipt exists', () => {
+
+        beforeEach(async () => {
+          await factories.readReceiptFactory.create({
+            conversationId: conversation.id,
+            userId: user.id,
+            userType: AuthorType.STAFF,
+            lastReadMessageId: messages[1].id // second message is read
+          })
+        })
+
+        it('returns the count of messages AFTER the last read message', async () => {
+          expect(messages.length).to.eq(5)
+          expect(
+            await computer.computeUnreadMessageCount(user.id, conversation.id)
+          ).to.eq(3)
+        })
+      })
+    });
+  })
+});


### PR DESCRIPTION
## Changes

- Added a computer service
- Included computed conversation fields in the GraphQL schema

e.g

```gql
query getConversations {
  conversations {
    id
    type
    _computed {
      # These only get computed when they are requested
      totalMessageCount 
      unreadMessageCount
    }
  }
}
```