### PR TITLE
ADD: Conversation subscriptions

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -19,7 +19,7 @@ const loadConfig = () : GoodChatConfig => {
     smoochApiKeySecret:     read.strict('SMOOCH_API_KEY_SECRET'),
     auth:                   authConfig(),
     jobs: {
-      delay: read.number('JOB_DELAY', 1000)
+      delay: read.number('JOB_DELAY', 0)
     },
     redis: {
       url: read.strict('REDIS_URL')

--- a/lib/initializers/index.ts
+++ b/lib/initializers/index.ts
@@ -5,6 +5,8 @@ import { each }           from '../utils/async'
 
 type NodeInitializer = { default: (cfg: GoodChatConfig) => unknown }
 
+let initialized = false;
+
 /**
  * Requires all the initializers of the current folder and calls them with the Goodchat config
  *
@@ -12,10 +14,16 @@ type NodeInitializer = { default: (cfg: GoodChatConfig) => unknown }
  * @param {GoodChatConfig} config
  */
 export async function boot(config: GoodChatConfig) : Promise<void> {
+  if (initialized) {
+    return;
+  }
+
   const initializers = _.omit(requireDir('.'), ['index'])
 
   await each(initializers, (mod: NodeInitializer) => {
     const { default: initializer } = mod
     return initializer(config)
   });
+
+  initialized = true;
 }

--- a/lib/initializers/lifecycle.ts
+++ b/lib/initializers/lifecycle.ts
@@ -1,0 +1,32 @@
+import db from '../db'
+import _  from 'lodash'
+
+async function touchConversation(id: number) {
+  await db.conversation.update({
+    where: { id },
+    data: { updatedAt: new Date() }
+  })
+}
+
+export default () => {
+  //
+  // Set-up lifecycle behavious of the GoodChat service
+  //
+  db.$use(async (params, next) => {
+    const result = await next(params);
+
+    //
+    // When a message gets created, we "touch" the conversation to update its timestamp
+    // That the update on the conversation record will allow to listen to changes on the conversation itself
+    //
+    if (params.model === 'Message' && params.action == 'create') {
+      const conversationId = _.get(params, 'args.data.conversationId');
+      if (_.isNumber(conversationId)) {
+        await touchConversation(conversationId);
+      }
+    }
+
+    return result;
+  })
+}
+

--- a/lib/routes/graphql/schema.gql
+++ b/lib/routes/graphql/schema.gql
@@ -13,6 +13,7 @@ type Query {
 type Subscription {
   messageEvent(conversationId: Int, actions: [SubscriptionAction]): MessageEvent!
   readReceiptEvent(conversationId: Int!): ReadReceiptEvent!
+  conversationEvent(conversationId: Int): ConversationEvent!
 }
 
 type Mutation {
@@ -116,6 +117,11 @@ type MessageEvent {
 type ReadReceiptEvent {
   action: SubscriptionAction!
   readReceipt: ReadReceipt!
+}
+
+type ConversationEvent {
+  action: SubscriptionAction!
+  conversation: Conversation!
 }
 
 type Customer {

--- a/lib/services/computer.ts
+++ b/lib/services/computer.ts
@@ -15,15 +15,14 @@ export async function computeUnreadMessageCount(staffId: number, conversationId:
       SELECT rr."conversationId", m."createdAt" AS timestamp
         FROM "ReadReceipt" rr
         JOIN "Message" m ON m.id = rr."lastReadMessageId"
-        WHERE rr."userType" = 'STAFF' AND rr."userId" = ${staffId}
+        WHERE (
+          rr."userType" = 'STAFF' AND
+          rr."userId" = ${staffId} AND
+          rr."conversationId" = ${conversationId}
+        )
     )
     SELECT count(m.id) FROM "Message" m
-      LEFT JOIN "ReadReceipt" rr ON (
-        rr."conversationId" = ${conversationId} AND
-        rr."userType" = 'STAFF' AND
-        rr."userId" = ${staffId}
-      )
-      LEFT JOIN last_read_timestamps AS lrt ON lrt."conversationId" = rr."conversationId"
+    LEFT JOIN last_read_timestamps AS lrt ON lrt."conversationId" = m."conversationId"
     WHERE m."conversationId" = ${conversationId}
       AND (m."createdAt" > lrt.timestamp OR lrt.timestamp IS NULL)
   `

--- a/lib/services/events/pubsub.ts
+++ b/lib/services/events/pubsub.ts
@@ -1,10 +1,15 @@
 import db                               from '../../db'
 import _                                from 'lodash'
-import { Message, Prisma, ReadReceipt } from '@prisma/client'
 import { RedisPubSub }                  from 'graphql-redis-subscriptions'
 import * as redis                       from '../../redis'
 import logger                           from '../../utils/logger'
 import { waitForEvent }                 from '../../utils/async'
+import {
+  Message,
+  Prisma,
+  ReadReceipt,
+  Conversation
+} from '@prisma/client'
 
 const SECOND = 1000;
 
@@ -42,7 +47,8 @@ const pubsub = new RedisPubSub({
 
 export enum PubSubEvent {
   MESSAGE       = 'message',
-  READ_RECEIPT  = 'read_receipt'
+  READ_RECEIPT  = 'read_receipt',
+  CONVERSATION  = 'conversation'
 }
 
 export enum PubSubAction {
@@ -55,6 +61,7 @@ export type RecordAction<N extends string, T> = { action: PubSubAction } & Recor
 
 export type MessageEvent      = RecordAction<"message", Message>
 export type ReadReceiptEvent  = RecordAction<"readReceipt", ReadReceipt>
+export type ConversationEvent  = RecordAction<"conversation", Conversation>
 
 const UNSUPPORTED = 'unsupported';
 
@@ -65,7 +72,8 @@ const EVENT_PER_MODEL = {
     Create a PubSubEvent and add a mapping here in order to support live updates for a new model
   */
   'Message': PubSubEvent.MESSAGE,
-  'ReadReceipt': PubSubEvent.READ_RECEIPT
+  'ReadReceipt': PubSubEvent.READ_RECEIPT,
+  'Conversation': PubSubEvent.CONVERSATION
 }
 
 type EventModelMap = typeof EVENT_PER_MODEL

--- a/specs/e2e/conversation_subscriptions.spec.ts
+++ b/specs/e2e/conversation_subscriptions.spec.ts
@@ -1,0 +1,499 @@
+import { before }                                from "mocha"
+import { gql }                                   from "apollo-server-core"
+import * as factories                            from '../factories'
+import { GoodChatPermissions }                   from "../../lib/typings/goodchat"
+import * as e2e                                  from "../spec_helpers/e2e"
+import { expect }                                from "chai"
+import { ConversationType, Staff }               from ".prisma/client"
+import _                                         from "lodash"
+import db                                        from "../../lib/db"
+
+const USER_EXTERNAL_ID = '747';
+
+describe('E2E/Subscriptions/Conversations', () => {
+  let serverInfo : e2e.TestServerInfo
+  let gqlClient : e2e.TestApolloClient
+  let staff : Staff
+
+  const makeCustomerConversation = () => factories.conversationFactory.create({ type: ConversationType.CUSTOMER })
+  const makePublicConversation = () => factories.conversationFactory.create({ type: ConversationType.PUBLIC })
+  const makePrivateConversation = () => factories.conversationFactory.create({ type: ConversationType.PRIVATE })
+  const makeMyPivateConversation = () => {
+    return factories.conversationFactory.create({ type: ConversationType.PRIVATE }, {
+      transient: { members: [staff] }
+    })
+  }
+
+  // ---- Setup E2E Server
+
+  before(async () => {
+    serverInfo = await e2e.bootTestServer();
+  })
+
+  after(async () => {
+    await e2e.teardownTestServer();
+  })
+
+  // ---- Seed database
+
+  beforeEach(async () => {
+    gqlClient  = e2e.buildGraphQLClient(serverInfo)
+
+    //
+    // We create the staff ahead of time just to create a private chat for it
+    // Permissions will still be defined by the authentication server
+    //
+    staff = await factories.staffFactory.create({ externalId: USER_EXTERNAL_ID })
+  })
+
+  afterEach(() => gqlClient.stop())
+
+  describe('Receiving conversation events', () => {
+
+    context('As an admin user', () => {
+
+      before(async () => {
+        e2e.mockAuthServerResponse({
+          userId: USER_EXTERNAL_ID,
+          permissions: [GoodChatPermissions.ADMIN],
+          displayName: 'Jane Doe'
+        })
+      })
+
+      after(() => e2e.cleanAllApiMocks())
+
+      _.each({
+        "customer chats": makeCustomerConversation,
+        "public chats": makePublicConversation,
+        "my private chats": makeMyPivateConversation
+      }, (makeConversation, type) => {
+
+        it(`I receive conversation create events from ${type}`, async () => {
+          const sub = e2e.createSubscription({
+            client: gqlClient,
+            query: gql`
+              subscription listenToConversations {
+                conversationEvent {
+                  action
+                  conversation {
+                    id
+                    metadata
+                  }
+                }
+              }
+            `
+          });
+
+          const conversation = await makeConversation();
+
+          await sub.waitForResults();
+
+          expect(sub.results).to.be.of.length(1);
+          expect(sub.results[0].data.conversationEvent).not.to.be.null;
+
+          const ev = sub.results[0].data.conversationEvent;
+
+          expect(ev.action).to.eq('CREATE');
+          expect(ev.conversation.id).to.eq(conversation.id);
+
+          sub.disconnect();
+        })
+
+        it(`I receive conversation update events from ${type}`, async () => {
+          const conversation = await makeConversation();
+
+          const sub = e2e.createSubscription({
+            client: gqlClient,
+            query: gql`
+              subscription listenToConversations {
+                conversationEvent {
+                  action
+                  conversation {
+                    id
+                    metadata
+                  }
+                }
+              }
+            `
+          });
+
+
+          await db.conversation.update({
+            where: { id: conversation.id },
+            data: {
+              metadata: { some: 'update' }
+            }
+          })
+
+          await sub.waitForResults();
+
+          expect(sub.results).to.be.of.length(1);
+          expect(sub.results[0].data.conversationEvent).not.to.be.null;
+
+          const ev = sub.results[0].data.conversationEvent;
+
+          expect(ev.action).to.eq('UPDATE');
+          expect(ev.conversation.id).to.eq(conversation.id);
+          expect(ev.conversation.metadata).to.deep.eq({ some: 'update' });
+
+          sub.disconnect();
+        })
+      });
+
+      it('I don\'t receive events from other private conversations', async () => {
+        const privateConversation = await makePrivateConversation();
+
+        const sub = e2e.createSubscription({
+          client: gqlClient,
+          query: gql`
+            subscription listenToConversations {
+              conversationEvent {
+                action
+                conversation {
+                  id
+                  metadata
+                }
+              }
+            }
+          `
+        });
+
+        await db.conversation.update({
+          where: { id: privateConversation.id },
+          data: {
+            metadata: { some: 'update' }
+          }
+        })
+
+        await sub.wait();
+
+        expect(sub.results).to.be.of.length(0);
+
+        sub.disconnect();
+      })
+    });
+
+    context('As a user with customer chat permissions', () => {
+
+      before(async () => {
+        e2e.mockAuthServerResponse({
+          userId: USER_EXTERNAL_ID,
+          permissions: [GoodChatPermissions.CHAT_CUSTOMER],
+          displayName: 'Jane Doe'
+        })
+      })
+
+      after(() => e2e.cleanAllApiMocks())
+
+      _.each({
+        "customer chats": makeCustomerConversation,
+        "public chats": makePublicConversation,
+        "my private chats": makeMyPivateConversation
+      }, (makeConv, type) => {
+
+        it(`I receive conversation update events from ${type}`, async () => {
+          const sub = e2e.createSubscription({
+            client: gqlClient,
+            query: gql`
+              subscription listenToConversations {
+                conversationEvent {
+                  action
+                  conversation {
+                    id
+                    metadata
+                  }
+                }
+              }
+            `
+          });
+
+          const conversation = await makeConv();
+
+          await sub.waitForResults();
+
+          expect(sub.results).to.be.of.length(1);
+          expect(sub.results[0].data.conversationEvent).not.to.be.null;
+
+          const ev = sub.results[0].data.conversationEvent;
+
+          expect(ev.action).to.eq('CREATE');
+          expect(ev.conversation.id).to.eq(conversation.id);
+
+          sub.disconnect();
+        })
+
+        it(`I receive conversation update events from ${type}`, async () => {
+          const conversation = await makeConv();
+
+          const sub = e2e.createSubscription({
+            client: gqlClient,
+            query: gql`
+              subscription listenToConversations {
+                conversationEvent {
+                  action
+                  conversation {
+                    id
+                    metadata
+                  }
+                }
+              }
+            `
+          });
+
+          await db.conversation.update({
+            where: { id: conversation.id },
+            data: {
+              metadata: { some: 'update' }
+            }
+          })
+
+          await sub.waitForResults();
+
+          expect(sub.results).to.be.of.length(1);
+          expect(sub.results[0].data.conversationEvent).not.to.be.null;
+
+          const ev = sub.results[0].data.conversationEvent;
+
+          expect(ev.action).to.eq('UPDATE');
+          expect(ev.conversation.id).to.eq(conversation.id);
+          expect(ev.conversation.metadata).to.deep.eq({ some: 'update' });
+
+          sub.disconnect();
+        })
+      });
+
+      it('I don\'t receive events from other private conversations', async () => {
+        const privateConversation = await makePrivateConversation();
+
+        const sub = e2e.createSubscription({
+          client: gqlClient,
+          query: gql`
+            subscription listenToConversations {
+              conversationEvent {
+                action
+                conversation {
+                  id
+                  metadata
+                }
+              }
+            }
+          `
+        });
+
+        await db.conversation.update({
+          where: { id: privateConversation.id },
+          data: {
+            metadata: { some: 'update' }
+          }
+        })
+
+        await sub.wait();
+
+        expect(sub.results).to.be.of.length(0);
+
+        sub.disconnect();
+      })
+    });
+
+    context('As a user with no permissions', () => {
+
+      before(async () => {
+        e2e.mockAuthServerResponse({
+          userId: USER_EXTERNAL_ID,
+          permissions: [],
+          displayName: 'Jane Doe'
+        })
+      })
+
+      after(() => e2e.cleanAllApiMocks())
+
+      _.each({
+        "public chats": makePublicConversation,
+        "my private chats": makeMyPivateConversation
+      }, (makeConv, type) => {
+
+        it(`I receive conversation create events from ${type}`, async () => {
+          const sub = e2e.createSubscription({
+            client: gqlClient,
+            query: gql`
+              subscription listenToConversations {
+                conversationEvent {
+                  action
+                  conversation {
+                    id
+                    metadata
+                  }
+                }
+              }
+            `
+          });
+
+          const conversation = await makeConv();
+
+          await sub.waitForResults();
+
+          expect(sub.results).to.be.of.length(1);
+          expect(sub.results[0].data.conversationEvent).not.to.be.null;
+
+          const ev = sub.results[0].data.conversationEvent;
+
+          expect(ev.action).to.eq('CREATE');
+          expect(ev.conversation.id).to.eq(conversation.id);
+
+          sub.disconnect();
+        })
+
+        it(`I receive conversation update events from ${type}`, async () => {
+          const conversation = await makeConv();
+
+          const sub = e2e.createSubscription({
+            client: gqlClient,
+            query: gql`
+              subscription listenToConversations {
+                conversationEvent {
+                  action
+                  conversation {
+                    id
+                    metadata
+                  }
+                }
+              }
+            `
+          });
+
+          await db.conversation.update({
+            where: { id: conversation.id },
+            data: {
+              metadata: { some: 'update' }
+            }
+          })
+
+          await sub.waitForResults();
+
+          expect(sub.results).to.be.of.length(1);
+          expect(sub.results[0].data.conversationEvent).not.to.be.null;
+
+          const ev = sub.results[0].data.conversationEvent;
+
+          expect(ev.action).to.eq('UPDATE');
+          expect(ev.conversation.id).to.eq(conversation.id);
+          expect(ev.conversation.metadata).to.deep.eq({ some: 'update' });
+
+          sub.disconnect();
+        })
+      });
+
+      it('I don\'t receive events from customer conversations', async () => {
+        const conversation = await makeCustomerConversation();
+
+        const sub = e2e.createSubscription({
+          client: gqlClient,
+          query: gql`
+            subscription listenToConversations {
+              conversationEvent {
+                action
+                conversation {
+                  id
+                  metadata
+                }
+              }
+            }
+          `
+        });
+
+        await db.conversation.update({
+          where: { id: conversation.id },
+          data: {
+            metadata: { some: 'update' }
+          }
+        })
+
+        await sub.wait();
+
+        expect(sub.results).to.be.of.length(0);
+
+        sub.disconnect();
+      })
+
+      it('I don\'t receive events from other private conversations', async () => {
+        const privateConversation = await makePrivateConversation();
+
+        const sub = e2e.createSubscription({
+          client: gqlClient,
+          query: gql`
+            subscription listenToConversations {
+              conversationEvent {
+                action
+                conversation {
+                  id
+                  metadata
+                }
+              }
+            }
+          `
+        });
+
+        await db.conversation.update({
+          where: { id: privateConversation.id },
+          data: {
+            metadata: { some: 'update' }
+          }
+        })
+
+        await sub.wait();
+
+        expect(sub.results).to.be.of.length(0);
+
+        sub.disconnect();
+      })
+    });
+
+    describe('Filtering', () => {
+
+      before(async () => {
+        e2e.mockAuthServerResponse({
+          userId: USER_EXTERNAL_ID,
+          permissions: [GoodChatPermissions.ADMIN],
+          displayName: 'Jane Doe'
+        })
+      })
+
+      after(() => e2e.cleanAllApiMocks());
+
+      it('filters on the specified conversation', async () => {
+        const conversation = await makePublicConversation();
+        const otherConversation = await makePublicConversation();
+
+        const sub = e2e.createSubscription({
+          client: gqlClient,
+          variables: { cid: conversation.id },
+          query: gql`
+            subscription listenToConversation($cid: Int) {
+              conversationEvent(conversationId: $cid) {
+                action
+                conversation {
+                  id
+                  metadata
+                }
+              }
+            }
+          `
+        });
+
+        await factories.messageFactory.create({ conversationId: otherConversation.id });
+
+        await sub.wait();
+
+        expect(sub.error).to.be.null
+        expect(sub.results, "No event for other conversation").to.be.of.length(0);
+
+        await factories.messageFactory.create({ conversationId: conversation.id });
+
+        await sub.waitForResults();
+
+        expect(sub.error).to.be.null
+        expect(sub.results, "Event received for conversation subscribed to").to.be.of.length(1);
+      })
+    })
+  });
+})

--- a/specs/e2e/conversation_subscriptions.spec.ts
+++ b/specs/e2e/conversation_subscriptions.spec.ts
@@ -37,7 +37,7 @@ describe('E2E/Subscriptions/Conversations', () => {
   // ---- Seed database
 
   beforeEach(async () => {
-    gqlClient  = e2e.buildGraphQLClient(serverInfo)
+    gqlClient = e2e.buildGraphQLClient(serverInfo)
 
     //
     // We create the staff ahead of time just to create a private chat for it

--- a/specs/integration/lifecycle.spec.ts
+++ b/specs/integration/lifecycle.spec.ts
@@ -1,0 +1,32 @@
+import { Conversation }  from '@prisma/client'
+import * as factories    from '../factories'
+import { expect }        from 'chai'
+import db                from '../../lib/db'
+import _                 from 'lodash'
+import {
+  createGoodchatServer,
+} from '../spec_helpers/agent'
+
+describe('Lifecycle events', () => {
+  before(async () => { await createGoodchatServer(); })
+
+  context('When a message is created', () => {
+    let conversation : Conversation
+
+    beforeEach(async () => {
+      conversation = await factories.conversationFactory.create({})
+    })
+
+    it('touches the conversation', async () => {
+      await factories.messageFactory.create({ conversationId: conversation.id })
+
+      const updatedConversation = await db.conversation.findFirst({
+        where: { id: conversation.id }
+      })
+
+      expect(
+        updatedConversation.updatedAt.getTime()
+      ).to.be.greaterThan(conversation.updatedAt.getTime())
+    })
+  })
+})

--- a/specs/samples/config.ts
+++ b/specs/samples/config.ts
@@ -15,7 +15,7 @@ export const BLANK_CONFIG : GoodChatConfig = {
     url: 'redis://127.0.0.1:6379'
   },
   jobs: {
-    delay: read.number('JOB_DELAY', 1000)
+    delay: read.number('JOB_DELAY', 0)
   },
   auth: {
     mode: GoodChatAuthMode.NONE

--- a/specs/spec_helpers/e2e.ts
+++ b/specs/spec_helpers/e2e.ts
@@ -219,7 +219,7 @@ export function createSubscription(params: SubscriptionTestParams) {
       return new Promise((done, fail) => {
         let step    = 2;
         let sum     = 0;
-        let timeout = opts.timeout ?? 100;
+        let timeout = opts.timeout ?? 200;
         let len     = opts.len ?? 1;
 
         const interval = setInterval(() => {

--- a/specs/spec_helpers/e2e.ts
+++ b/specs/spec_helpers/e2e.ts
@@ -94,7 +94,7 @@ export class TestApolloClient extends ApolloClient<any> {
   private wsLink : WebSocketLink
 
   constructor(serverInfo: TestServerInfo) {
-    const { url, host } = serverInfo;
+    const { host } = serverInfo;
 
     const wsLink = new WebSocketLink({
       uri: `ws://${host}:${port}/graphql/subscriptions`,
@@ -219,7 +219,7 @@ export function createSubscription(params: SubscriptionTestParams) {
       return new Promise((done, fail) => {
         let step    = 2;
         let sum     = 0;
-        let timeout = opts.timeout ?? 200;
+        let timeout = opts.timeout ?? 1000;
         let len     = opts.len ?? 1;
 
         const interval = setInterval(() => {

--- a/specs/spec_helpers/e2e.ts
+++ b/specs/spec_helpers/e2e.ts
@@ -245,6 +245,5 @@ export function createSubscription(params: SubscriptionTestParams) {
       return error;
     }
   }
-
 }
 

--- a/specs/spec_helpers/utils.ts
+++ b/specs/spec_helpers/utils.ts
@@ -1,5 +1,4 @@
-import { pubsub }   from "../../lib/services/events";
-import { AnyFunc }  from "../../lib/typings/lang";
+import { pubsub }   from "../../lib/services/events"
 
 export function waitForPubSub(ev: string, count: number = 1) : Promise<any[]> {
   const events : any[] = [];
@@ -20,6 +19,6 @@ export function waitForPubSub(ev: string, count: number = 1) : Promise<any[]> {
         pubsub.unsubscribe(id)
         reject(new Error('waitForPubSub timeout'))
       }
-    }, 100)
+    }, 1000)
   })
 }

--- a/specs/spec_helpers/utils.ts
+++ b/specs/spec_helpers/utils.ts
@@ -1,0 +1,25 @@
+import { pubsub }   from "../../lib/services/events";
+import { AnyFunc }  from "../../lib/typings/lang";
+
+export function waitForPubSub(ev: string, count: number = 1) : Promise<any[]> {
+  const events : any[] = [];
+  let finished = false;
+  return new Promise(async (done, reject) => {
+    const id = await pubsub.subscribe(ev, (payload) => {
+      events.push(payload);
+      if (!finished && events.length === count) {
+        finished = true;
+        done(events);
+        pubsub.unsubscribe(id)
+      }
+    })
+
+    setTimeout(() => {
+      if (!finished) {
+        finished = true;
+        pubsub.unsubscribe(id)
+        reject(new Error('waitForPubSub timeout'))
+      }
+    }, 100)
+  })
+}

--- a/specs/unit/services/events.spec.ts
+++ b/specs/unit/services/events.spec.ts
@@ -1,11 +1,10 @@
-import { pubsub, PubSubEvent }   from '../../../lib/services/events/pubsub'
-import * as factories            from '../../factories'
-import { waitFor }               from '../../../lib/utils/async'
-import { expect }                from 'chai'
 import { AuthorType, Staff }     from '.prisma/client'
+import { waitForPubSub }         from '../../spec_helpers/utils'
+import { PubSubEvent }           from '../../../lib/services/events/pubsub'
+import * as factories            from '../../factories'
+import { expect }                from 'chai'
 import db                        from '../../../lib/db'
 import _                         from 'lodash'
-import { waitForPubSub }         from '../../spec_helpers/utils'
 
 describe('Services/events', () => {
   describe('PubSub', () => {
@@ -48,10 +47,7 @@ describe('Services/events', () => {
       })
 
       it('fires multiple MESSAGE updated events for batch updateMany operations', async () => {
-        await Promise.all([
-          factories.messageFactory.createList(3),
-          waitForPubSub(PubSubEvent.MESSAGE, 3)
-        ]);
+        await factories.messageFactory.createList(3);
 
         const update = db.message.updateMany({
           where: {},
@@ -74,10 +70,7 @@ describe('Services/events', () => {
       })
 
       it('fires multiple MESSAGE deleted events for batch deleteMany operations', async () => {
-        await Promise.all([
-          factories.messageFactory.createList(3),
-          waitForPubSub(PubSubEvent.MESSAGE, 3)
-        ])
+        await factories.messageFactory.createList(3);
 
         const del = db.message.deleteMany({ where: {} });
 


### PR DESCRIPTION
Changes:

- Added logic to "touch" conversations on message creation. That will allow subscriptions to fire on the conversation itself when a message is received
- Added Conversation pub-sub events
- Added GQL `conversationEvent` subscription
- Added specs for all of the above
- Refactored: pubsub specs with a `waitForPubSub` helper

e.g subscription

```gql
subscription listenToConversations {
  conversationEvent {
    action # e.g update, create, delete
    conversation {
      id
      metadata
      messages {
        id
        content
      }
     }
   }
}
```